### PR TITLE
DT-Cleanup and Switch to Zephyr-Tag

### DIFF
--- a/boards/mimxrt1060_evk_mimxrt1062_qspi_B.overlay
+++ b/boards/mimxrt1060_evk_mimxrt1062_qspi_B.overlay
@@ -10,9 +10,9 @@ microbus_i2c: &arduino_i2c {};
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 &mikroe_stepper_driver {
-	sleep-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;	/* D2 */
-	dir-gpios = <&arduino_header 9 0>;			/* D3 */
-	step-gpios = <&arduino_header 10 0>;			/* D4 */
+	sleep-gpios = <&arduino_header 9 GPIO_ACTIVE_LOW>;	/* D3 */
+	dir-gpios = <&arduino_header 10 0>;			/* D4 */
+	step-gpios = <&arduino_header 8 0>;			/* D2 */
 	en-gpios = <&arduino_header 11 0>;			/* D5 */
 	m0-gpios = <&mikroe_stepper_gpios 0 0>;			/* S0 */
 	m1-gpios = <&mikroe_stepper_gpios 1 0>;			/* S1 */
@@ -20,8 +20,7 @@ microbus_i2c: &arduino_i2c {};
 	/* Timing source configuration. */
 	counter = <&pit0_channel0>;
 	accurate-steps = <15>;
-	acceleration = <800>;
-	// acceleration = <200>;
+	acceleration = <1600>;
 };
 
 &pit0_channel0 {

--- a/boards/nucleo_f303re.overlay
+++ b/boards/nucleo_f303re.overlay
@@ -20,17 +20,10 @@ microbus_i2c: &arduino_i2c {};
 	/* Timing source configuration. */
 	counter = <&counter2>;
 	acceleration = <1600>;
-	// acceleration = <200>;
 };
 
 &timers2 {
 	status = "okay";
-
-	pwm2: pwm {
-		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa5>;
-		pinctrl-names = "default";
-	};
 
 	counter2: counter {
 		 status = "okay";

--- a/boards/nucleo_f767zi.overlay
+++ b/boards/nucleo_f767zi.overlay
@@ -20,17 +20,10 @@ microbus_i2c: &arduino_i2c {};
 	/* Timing source configuration. */
 	counter = <&counter2>;
 	acceleration = <1600>;
-	// acceleration = <200>;
 };
 
 &timers2 {
 	status = "okay";
-
-	pwm2: pwm {
-		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa5>;
-		pinctrl-names = "default";
-	};
 
 	counter2: counter {
 		 status = "okay";

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
       # We are using a fork of zephyr of the tiacsys organization
       remote: tiacsys
       # Zephyr branch used for this demo
-      revision: acceleration-demo
+      revision: ew-2025-demo-20250309
       # Allows for calling o west commands without giving script source paths every time
       west-commands: scripts/west-commands.yml
       # Import the external modules required for this project using a whitelist. During


### PR DESCRIPTION
- Cleanup of overlay files, removing uncommented and unnecessary entries and fixing acceleration for the mimxrt1060 board.
- Switch from branch to tag for the Zephyr revision to ensure stability in case of further work on the branch.